### PR TITLE
Update Oiyokan Lib: 1.18.20210526a, Implementation: Changed to pass OiyoInfo instance from the outside., トランザクション分離レベルを画面で指定することは廃止。

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,10 @@
+# Release 0.8 (2021-05-26)
+
+## EN
+
+- Update Oiyokan Lib: 1.18.20210526a
+- Implementation: Changed to pass OiyoInfo instance from the outside.
+
 # Release 0.7 (2021-05-22)
 
 ## EN

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>jp.igapyon.oiyokan</groupId>
 	<artifactId>oiyokan-initializr</artifactId>
-	<version>0.7.20210522a</version>
+	<version>0.8.20210526a</version>
 	<name>oiyokan-initializr</name>
 	<description>Oyekan Initializr is a generator for creating `oiyokan-settings.json`.</description>
 	<url>https://github.com/igapyon/oiyokan-initializr</url>
@@ -77,7 +77,7 @@
 		<dependency>
 			<groupId>jp.igapyon.oiyokan</groupId>
 			<artifactId>oiyokan</artifactId>
-			<version>1.16.20210522a</version>
+			<version>1.18.20210526a</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/jp/oiyokan/initializr/OiyokanInitializrConstants.java
+++ b/src/main/java/jp/oiyokan/initializr/OiyokanInitializrConstants.java
@@ -19,7 +19,7 @@ package jp.oiyokan.initializr;
  * Oiyokan Initializr の定数.
  */
 public class OiyokanInitializrConstants {
-    public static final String VERSION = "0.7.20210522a";
+    public static final String VERSION = "0.8.20210526a";
 
     /**
      * 通常は FALSE 運用.

--- a/src/main/java/jp/oiyokan/initializr/ctrl/ThInitializrSetupDatabaseCtrl.java
+++ b/src/main/java/jp/oiyokan/initializr/ctrl/ThInitializrSetupDatabaseCtrl.java
@@ -58,9 +58,6 @@ public class ThInitializrSetupDatabaseCtrl {
         }
         database.setJdbcUser(""); // JDBC User.
         database.setJdbcPassPlain(""); // JDBC Password.
-        if (database.getTransactionIsolation() == null) {
-            database.setTransactionIsolation("");
-        }
 
         model.addAttribute("database", database);
         initializrBean.setMsgSuccess(null);

--- a/src/main/java/jp/oiyokan/initializr/ctrl/ThInitializrSetupDatabaseCtrl.java
+++ b/src/main/java/jp/oiyokan/initializr/ctrl/ThInitializrSetupDatabaseCtrl.java
@@ -59,7 +59,7 @@ public class ThInitializrSetupDatabaseCtrl {
         database.setJdbcUser(""); // JDBC User.
         database.setJdbcPassPlain(""); // JDBC Password.
         if (database.getTransactionIsolation() == null) {
-            database.setTransactionIsolation("Connection.TRANSACTION_READ_COMMITTED");
+            database.setTransactionIsolation("");
         }
 
         model.addAttribute("database", database);

--- a/src/main/resources/oiyokan-web-template/pom.xml
+++ b/src/main/resources/oiyokan-web-template/pom.xml
@@ -24,7 +24,7 @@
 		<dependency>
 			<groupId>jp.igapyon.oiyokan</groupId>
 			<artifactId>oiyokan</artifactId>
-			<version>1.16.20210522a</version>
+			<version>1.18.20210526a</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/resources/oiyokan-web-template/src/main/java/com/example/DemoOData4Register.java
+++ b/src/main/resources/oiyokan-web-template/src/main/java/com/example/DemoOData4Register.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import jp.oiyokan.OiyokanOdata4RegisterImpl;
+import jp.oiyokan.common.OiyoInfo;
 
 @RestController
 public class DemoOData4Register {
@@ -15,6 +16,7 @@ public class DemoOData4Register {
 
     @RequestMapping(ODATA_ROOTPATH + "/*")
     public void serv(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException {
-        OiyokanOdata4RegisterImpl.serv(req, resp, ODATA_ROOTPATH);
+        final OiyoInfo oiyoInfo = new OiyoInfo();
+        OiyokanOdata4RegisterImpl.serv(oiyoInfo, req, resp, ODATA_ROOTPATH);
     }
 }

--- a/src/main/resources/templates/oiyokan/initializrSetupDatabase.html
+++ b/src/main/resources/templates/oiyokan/initializrSetupDatabase.html
@@ -155,26 +155,6 @@
 
                 <br />
 
-                <div class="mdl-selectfield mdl-js-selectfield">
-                  <label class="mdl-selectfield__label" for="transactionIsolation">Transaction Isolation</label>
-                  <select class="mdl-selectfield__select" id="transactionIsolation" required
-                    th:field="*{transactionIsolation}">
-                    <option th:value="Connection.TRANSACTION_READ_UNCOMMITTED"
-                      th:text="Connection.TRANSACTION_READ_UNCOMMITTED"
-                      th:selected="${transactionIsolation == 'Connection.TRANSACTION_READ_UNCOMMITTED'}" />
-                    <option th:value="Connection.TRANSACTION_READ_COMMITTED"
-                      th:text="Connection.TRANSACTION_READ_COMMITTED"
-                      th:selected="${transactionIsolation == 'Connection.TRANSACTION_READ_COMMITTED'}" />
-                    <option th:value="Connection.TRANSACTION_REPEATABLE_READ"
-                      th:text="Connection.TRANSACTION_REPEATABLE_READ"
-                      th:selected="${transactionIsolation == 'Connection.TRANSACTION_REPEATABLE_READ'}" />
-                    <option th:value="Connection.TRANSACTION_SERIALIZABLE" th:text="Connection.TRANSACTION_SERIALIZABLE"
-                      th:selected="${transactionIsolation == 'Connection.TRANSACTION_SERIALIZABLE'}" />
-                  </select>
-                </div>
-
-                <br />
-
                 <div>
                   <button class="mdl-button mdl-js-button mdl-button--raised" type="submit" name="connTest">Connection
                     Test</button>


### PR DESCRIPTION
- Update Oiyokan Lib: 1.18.20210526a
- Implementation: Changed to pass OiyoInfo instance from the outside.
- トランザクション分離レベルを画面で指定することは廃止。